### PR TITLE
Implement null checks for safety

### DIFF
--- a/FMDE/src/org/upb/fmde/de/categories/concrete/finsets/FinSets.java
+++ b/FMDE/src/org/upb/fmde/de/categories/concrete/finsets/FinSets.java
@@ -30,7 +30,13 @@ public class FinSets implements LabelledCategory<FinSet, TotalFunction>,
 	@Override
 	public TotalFunction compose(TotalFunction f, TotalFunction g) {
 		TotalFunction f_then_g = new TotalFunction(f.src(), f + ";" + g, g.trg());
-		f.src().elts().forEach(x -> f_then_g.addMapping(x, g.map(f.map(x))));
+		f.src().elts().forEach(x -> {
+			Object mapping = g.map(f.map(x));
+			if (mapping == null) {
+				throw new IllegalArgumentException("Functions cannot be composed.");
+			}
+			f_then_g.addMapping(x, mapping);
+		});
 		return f_then_g;
 	}
 

--- a/FMDE/src/org/upb/fmde/de/categories/concrete/finsets/TotalFunction.java
+++ b/FMDE/src/org/upb/fmde/de/categories/concrete/finsets/TotalFunction.java
@@ -27,7 +27,13 @@ public class TotalFunction extends LabelledArrow<FinSet> implements ComparableAr
 
 	public boolean isTheSameAs(TotalFunction f) {
 		return source.elts().stream()
-					 .allMatch(x -> map(x) != null && map(x).equals(f.map(x)));
+					 .allMatch(x -> {
+						 if (map(x) == null) {
+							 throw new IllegalArgumentException("Detected a null value mapping. " +
+									 "Functions may have unequal domains.");
+						 }
+						 return map(x).equals(f.map(x));
+					 });
 	}
 	
 	public Map<Object, Object> mappings(){


### PR DESCRIPTION
Hi Tony, as suggested by you earlier today, I've implemented null checks in `compose` and `isTheSameAs` to fail fast on pairs of total functions that are not defined on the same domain.
